### PR TITLE
AuthenticationEntryPoint 구현 및 관련 보안설정 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/finalproject/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.fastcampus.finalproject.config;
 import com.fastcampus.finalproject.config.security.jwt.filter.JwtAuthenticationFilter;
 import com.fastcampus.finalproject.config.security.jwt.filter.JwtAuthorizationFilter;
 import com.fastcampus.finalproject.config.security.jwt.filter.JwtExceptionTranslationFilter;
+import com.fastcampus.finalproject.config.security.jwt.handler.JwtAccessDeniedHandler;
+import com.fastcampus.finalproject.config.security.jwt.handler.JwtAuthenticationEntryPoint;
 import com.fastcampus.finalproject.config.security.jwt.handler.JwtAuthenticationFailureHandler;
 import com.fastcampus.finalproject.config.security.jwt.handler.JwtAuthenticationSuccessHandler;
 import com.fastcampus.finalproject.config.security.jwt.provider.CustomAuthenticationProvider;
@@ -59,6 +61,11 @@ public class SecurityConfig {
                 .antMatchers("/sign-up", "/sign-up/**").permitAll()
                 .antMatchers("/login").permitAll()
                 .anyRequest().authenticated();
+
+        httpSecurity
+                .exceptionHandling()
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                .accessDeniedHandler(new JwtAccessDeniedHandler());
 
         httpSecurity
                 .addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/fastcampus/finalproject/config/security/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/fastcampus/finalproject/config/security/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.fastcampus.finalproject.config.security.jwt.handler;
 
+import com.fastcampus.finalproject.dto.ErrorResponseWrapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -9,8 +11,16 @@ import java.io.IOException;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+    private static final String ERROR_CODE_NO_TOKEN = "NO_TOKEN";
+    private static final String ERROR_MESSAGE_NO_TOKEN = "요청에 필요한 토큰이 없습니다.";
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        ErrorResponseWrapper errorResponse = new ErrorResponseWrapper(ERROR_CODE_NO_TOKEN, ERROR_MESSAGE_NO_TOKEN).unauthorized();
+        String serializedErrorResponse = new ObjectMapper().writeValueAsString(errorResponse);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(serializedErrorResponse);
+        response.getWriter().flush();
     }
 }


### PR DESCRIPTION
## Related Issues
+ solved #21

<br>

## What does this PR do?
 + [x] 사용자 요청에 Bearer 토큰이 없을 경우, JwtAuthenticationEntryPoint에서 요청 메시지 바디에 관련 에러 메시지를 작성합니다.
 + [x] JwtAuthenticationEntryPoint.class를 SecurityConfig에서 인증 예외 처리 클래스로 등록합니다.

<br>