### PR TITLE
fix: 한국 시간으로 변경하기 위해 auditing 코드 제거

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
+++ b/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
+//@EnableJpaAuditing
 public class FinalProjectApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/fastcampus/finalproject/entity/BaseTimeEntity.java
+++ b/src/main/java/com/fastcampus/finalproject/entity/BaseTimeEntity.java
@@ -5,23 +5,33 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public class BaseTimeEntity {
 
-    @CreatedDate
-    @Column(updatable = false, nullable = false)
-    private LocalDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+//    @CreatedDate
+//    @Column(updatable = false, nullable = false)
+//    private LocalDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+//
+//    @LastModifiedDate
+//    @Column(nullable = false)
+//    private LocalDateTime lastModifiedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+    private ZonedDateTime createAt;
+    private ZonedDateTime lastModifiedAt;
 
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime lastModifiedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+    @PrePersist
+    public void prePersist() {
+        this.createAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.lastModifiedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.lastModifiedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
 }


### PR DESCRIPTION
## Related Issues
+ solved #25 

<br>

## What does this PR do?
 + [x] BaseTimeEntity에서 코드 변경

<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
