### PR TITLE
feat: spring boot의 default timezone을 Asia/Seoul로 적용되도록 코드 추가

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
+++ b/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
@@ -4,9 +4,16 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
-//@EnableJpaAuditing
 public class FinalProjectApplication {
+
+	@PostConstruct
+	void started() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(FinalProjectApplication.class, args);


### PR DESCRIPTION
## Related Issues
+ solved 

<br>

## What does this PR do?
 + [x] Asia/Seoul로 적용되도록 코드 추가

<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
