### PR TITLE
fix: avatar 데이터가 순서대로 응답될 수 있도록 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/dto/AvatarPageDto.java
+++ b/src/main/java/com/fastcampus/finalproject/dto/AvatarPageDto.java
@@ -73,9 +73,9 @@ public class AvatarPageDto {
         public static class AvatarPageDummyDto {
 
             private AvatarSelectionDto avatar1;
+            private AvatarSelectionDto avatar2;
             private AvatarSelectionDto avatar3;
             private AvatarSelectionDto avatar4;
-            private AvatarSelectionDto avatar2;
             private List<BackgroundDto> backgroundList;
 
             public AvatarPageDummyDto(List<AvatarSelectionDto> avatarDtoList, List<BackgroundDto> backgroundDtoList) {

--- a/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
@@ -92,7 +92,6 @@ public class ProjectService {
         File target = new File(flaskConfig.getFilePath() + uuid + "_" + audioFileName);
 
         try {
-            target.createNewFile();
             fos = new FileOutputStream(target);
             fos.write(decode);
             fos.close();


### PR DESCRIPTION
## Related Issues
+ none

<br>

## What does this PR do?
 + [x] avatar1, avatar2, avatar3, avatar4 와 같이 순서대로 dto가 구성될 수 있도록 변경
