### PR TITLE
JwtExceptionTranslationFilter 응답 메시지 한글 깨짐 에러 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/config/security/jwt/filter/JwtExceptionTranslationFilter.java
+++ b/src/main/java/com/fastcampus/finalproject/config/security/jwt/filter/JwtExceptionTranslationFilter.java
@@ -38,7 +38,8 @@ public class JwtExceptionTranslationFilter extends OncePerRequestFilter {
             }
 
             String serializedErrorResponse = new ObjectMapper().writeValueAsString(errorResponse);
-
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
             response.getWriter().write(serializedErrorResponse);
             response.getWriter().flush();
         }


### PR DESCRIPTION
## Related Issues
+ 해당 없음

<br>

## What does this PR do?
 + [x] JWT 토큰 검증 관련 예외 발생 시 전달되는 응답 메시지의 ContentType을 'application/json'으로, CharacterEncoding을 UTF-8로 설정
 + [x] 한글로 된 에러 메시지가 깨져 나오는 문제를 수정하였음 

<br>

