### PR TITLE
가장 오래된 프로젝트 및 영상 삭제, 파일 확장자가 반영되는 버그 해결

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
+++ b/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fastcampus.finalproject.config.YmlFlaskConfig;
+import com.fastcampus.finalproject.enums.FileType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,14 +25,18 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadFile(File uploadFile, String userPath) {
-        String bucketPath = userPath + "/" + uploadFile.getName();
+    public String uploadFile(File uploadFile, FileType fileType, String projectPath) {
+        String bucketPath = projectPath + "/" + fileType.getValue() + "/" + uploadFile.getName();
         return putS3(uploadFile, bucketPath);
     }
 
-    public void removeFile(String projectPath, String fileName) {
-        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, projectPath + "/" + fileName));
-        removeLocalFile(new File(flaskConfig.getFilePath() + "/" + fileName));
+    public void removeFile(String projectPath, FileType fileType, String fileName) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, projectPath + "/" + fileType.getValue() + "/" + fileName));
+
+        File file = new File(flaskConfig.getFilePath() + "/" + fileName);
+        if(file.exists()) {
+            removeLocalFile(file);
+        }
     }
 
     private String putS3(File uploadFile, String bucketPath) {

--- a/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
+++ b/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
@@ -1,9 +1,7 @@
 package com.fastcampus.finalproject.aws;
 
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.*;
 import com.fastcampus.finalproject.config.YmlFlaskConfig;
 import com.fastcampus.finalproject.enums.FileType;
 import lombok.RequiredArgsConstructor;
@@ -30,13 +28,21 @@ public class S3Uploader {
         return putS3(uploadFile, bucketPath);
     }
 
-    public void removeFile(String parentPath, FileType fileType, String fileName) {
-        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, parentPath + "/" + fileType.getValue() + "/" + fileName));
+    public void removeFile(String parentPath, FileType fileType, String fileName, String fileExtension) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, parentPath + "/" + fileType.getValue() + "/" + fileName + fileExtension));
 
         File file = new File(flaskConfig.getFilePath() + "/" + fileName);
         if(file.exists()) {
             removeLocalFile(file);
         }
+    }
+
+    /*
+     * 회원 탈퇴 기능이 추가되면 영상 디렉토리 삭제하는 데 사용
+     */
+    public void removeDirectory(String parentPath) {
+        DeleteObjectsResult deleteObjectsResult = amazonS3Client.deleteObjects(new DeleteObjectsRequest(bucket)
+                .withKeys(parentPath));
     }
 
     private String putS3(File uploadFile, String bucketPath) {

--- a/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
+++ b/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
@@ -25,13 +25,13 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadFile(File uploadFile, FileType fileType, String projectPath) {
-        String bucketPath = projectPath + "/" + fileType.getValue() + "/" + uploadFile.getName();
+    public String uploadFile(File uploadFile, FileType fileType, String parentPath) {
+        String bucketPath = parentPath + "/" + fileType.getValue() + "/" + uploadFile.getName();
         return putS3(uploadFile, bucketPath);
     }
 
-    public void removeFile(String projectPath, FileType fileType, String fileName) {
-        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, projectPath + "/" + fileType.getValue() + "/" + fileName));
+    public void removeFile(String parentPath, FileType fileType, String fileName) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, parentPath + "/" + fileType.getValue() + "/" + fileName));
 
         File file = new File(flaskConfig.getFilePath() + "/" + fileName);
         if(file.exists()) {

--- a/src/main/java/com/fastcampus/finalproject/entity/Video.java
+++ b/src/main/java/com/fastcampus/finalproject/entity/Video.java
@@ -17,14 +17,18 @@ public class Video extends BaseTimeEntity {
     private String name;
 
     @Column(nullable = false)
+    private String videoFileName;
+
+    @Column(nullable = false)
     private String videoUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_UID")
     private UserBasic user;
 
-    public Video(String videoResponse, String videoUrl, UserBasic user) {
-        this.name = videoResponse;
+    public Video(String name, String videoFileName, String videoUrl, UserBasic user) {
+        this.name = name;
+        this.videoFileName = videoFileName;
         this.videoUrl = videoUrl;
         this.user = user;
     }

--- a/src/main/java/com/fastcampus/finalproject/enums/FileType.java
+++ b/src/main/java/com/fastcampus/finalproject/enums/FileType.java
@@ -1,0 +1,17 @@
+package com.fastcampus.finalproject.enums;
+
+public enum FileType {
+
+    AUDIO("audio"),
+    VIDEO("video");
+
+    private final String value;
+
+    FileType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
@@ -168,7 +168,7 @@ public class ProjectService {
 
         s3Uploader.removeFile(beMappedS3AudioPath(findProject), FileType.AUDIO, findProject.getAudioFileName(), flaskConfig.getAudioExtension());
 
-        findProject.changeAudioFileName(saveName.substring(saveName.indexOf(".")));
+        findProject.changeAudioFileName(saveName.substring(0, saveName.lastIndexOf(".")));
         findProject.changeTotalAudioURl(ProjectDefaultType.EMPTY.getValue());
     }
 
@@ -262,7 +262,7 @@ public class ProjectService {
             //비디오가 생성되면 더 이상 로컬에 있는 비디오 파일은 무의미. 바로 지워주도록 하자
             s3Uploader.removeLocalFile(file);
 
-            Video savedVideo = videoRepository.save(new Video(findProject.getName(), file.getName().substring(file.getName().indexOf(".")), savedFileBucketUrl, findProject.getUser()));
+            Video savedVideo = videoRepository.save(new Video(findProject.getName(), file.getName().substring(0, file.getName().lastIndexOf(".")), savedFileBucketUrl, findProject.getUser()));
 
             return new CompleteAvatarPageResponse("Success", savedVideo);
         } else {


### PR DESCRIPTION
## Related Issues
+ solved #37
+ solved #46
+ solved #49 

<br>

## What does this PR do?
 - [x] 프로젝트 또는 영상이 5개를 초과할 경우, DB와 S3에서 해당 파일 삭제하는 기능 추가
 - [x] 음성 파일 업로드 시 파일 확장자만 반영되는 버그 확인. (`fileName.substring(0, fileName.lastIndexOf('.')` 로 해결)
 - [x] Video 엔티티에 videoFileName 컬럼 추가
<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
