### PR TITLE
계정관리 기능 구현 및 버그 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/controller/UserController.java
+++ b/src/main/java/com/fastcampus/finalproject/controller/UserController.java
@@ -24,6 +24,7 @@ import io.jsonwebtoken.security.SecurityException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -67,7 +68,7 @@ public class UserController {
     }
 
     @PostMapping("/my-page")
-    public ResponseWrapper changePassword(@Valid NewPasswordDto newPasswordDto) {
+    public ResponseWrapper changePassword(@RequestBody @Valid NewPasswordDto newPasswordDto) {
         Long userId = AuthUtil.getCurrentUserUid();
         userService.changePassword(userId, newPasswordDto);
 

--- a/src/main/java/com/fastcampus/finalproject/dto/request/NewPasswordDto.java
+++ b/src/main/java/com/fastcampus/finalproject/dto/request/NewPasswordDto.java
@@ -1,14 +1,17 @@
 package com.fastcampus.finalproject.dto.request;
 
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
-@Getter
+@Data
+@NoArgsConstructor
 public class NewPasswordDto {
 
     @NotNull
-    private final String newPassword;
+    private String newPassword;
 
     public NewPasswordDto(String newPassword) {
         this.newPassword = newPassword;

--- a/src/main/java/com/fastcampus/finalproject/service/UserService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/UserService.java
@@ -9,6 +9,7 @@ import com.fastcampus.finalproject.enums.LoginType;
 import com.fastcampus.finalproject.exception.DuplicateIdException;
 import com.fastcampus.finalproject.repository.NativeLoginUserRepository;
 import com.fastcampus.finalproject.repository.UserRepository;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -45,8 +46,13 @@ public class UserService {
     }
 
     public boolean changePassword(Long userUid, NewPasswordDto newPasswordDto) {
-        NativeLoginUser nativeLoginUser = nativeLoginUserRepository.findByUser(new UserBasic(userUid)).orElseThrow();
+        Optional<NativeLoginUser> nativeLoginUserOptional = nativeLoginUserRepository.findByUser(new UserBasic(userUid));
 
+        if (nativeLoginUserOptional.isEmpty()) {
+            return false;
+        }
+
+        NativeLoginUser nativeLoginUser = nativeLoginUserOptional.get();
         nativeLoginUser.changePassword(bCryptPasswordEncoder.encode(newPasswordDto.getNewPassword()));
         nativeLoginUser.changeLastUpdatedTime(LocalDateTime.now());
 


### PR DESCRIPTION
## Related Issues
+ solved #54 

- 계정관리 API `/my-page` 관련 기능(비밀번호 변경 기능)을 구현하였으며, 버그를 수정했습니다.

<br>

## What does this PR do?
 + [x] UserController 클래스 changePassword 메서드 매개변수에 @RequestBody 어노테이션이 없어 Parameter binding이 안 되는 버그를 수정
 + [x] UserService가 NativeLoginUserRepository에서 사용자 정보를 찾지 못할 경우 NoSuchElementException을 throw 하지 않고 호출자(UserController)에게 false 값만을 반환하도록 수정
 + [x] NewPasswordDto 클래스의 롬복 어노테이션 수정

<br>
