### PR TITLE
fix: 음성 파일을 생성하면 기존의 음성 파일을 로컬에서 삭제되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
+++ b/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
@@ -31,7 +31,7 @@ public class S3Uploader {
     public void removeFile(String parentPath, FileType fileType, String fileName, String fileExtension) {
         amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, parentPath + "/" + fileType.getValue() + "/" + fileName + fileExtension));
 
-        File file = new File(flaskConfig.getFilePath() + "/" + fileName);
+        File file = new File(flaskConfig.getFilePath() + "/" + fileName + fileExtension);
         if(file.exists()) {
             removeLocalFile(file);
         }


### PR DESCRIPTION
## Related Issues
+ none

<br>

## What does this PR do?
 + [x] S3Uploader 클래스의 removeFile 메서드 내용 변경

<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
