### PR TITLE
JWT 리프레시 토큰을 이용한 새 토큰쌍 발행 기능 구현/수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/finalproject/config/SecurityConfig.java
@@ -83,6 +83,7 @@ public class SecurityConfig {
         httpSecurity
                 .authorizeRequests()
                 .antMatchers("/sign-up", "/sign-up/**").permitAll()
+                .antMatchers("/token/refresh").permitAll()
                 .antMatchers("/login").permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/fastcampus/finalproject/config/security/jwt/utils/AccessTokenUtility.java
+++ b/src/main/java/com/fastcampus/finalproject/config/security/jwt/utils/AccessTokenUtility.java
@@ -79,5 +79,18 @@ public class AccessTokenUtility implements InitializingBean {
         Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
         return true;
     }
+
+    public TokenValidityCode evaluateTokenValidity(String token) {
+        TokenValidityCode result;
+        try {
+            validateToken(token);
+            result = TokenValidityCode.VALID;
+        } catch (ExpiredJwtException exception) {
+            result = TokenValidityCode.EXPIRED;
+        } catch (Exception exception) {
+            result = TokenValidityCode.INVALID;
+        }
+        return result;
+    }
 }
 

--- a/src/main/java/com/fastcampus/finalproject/config/security/jwt/utils/RefreshTokenUtility.java
+++ b/src/main/java/com/fastcampus/finalproject/config/security/jwt/utils/RefreshTokenUtility.java
@@ -101,4 +101,17 @@ public class RefreshTokenUtility implements InitializingBean {
         String subject = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
         return Long.valueOf(subject);
     }
+
+    public TokenValidityCode evaluateTokenValidity(String token) {
+        TokenValidityCode result;
+        try {
+            validateToken(token);
+            result = TokenValidityCode.VALID;
+        } catch (ExpiredJwtException exception) {
+            result = TokenValidityCode.EXPIRED;
+        } catch (Exception exception) {
+            result = TokenValidityCode.INVALID;
+        }
+        return result;
+    }
 }

--- a/src/main/java/com/fastcampus/finalproject/config/security/jwt/utils/TokenValidityCode.java
+++ b/src/main/java/com/fastcampus/finalproject/config/security/jwt/utils/TokenValidityCode.java
@@ -1,0 +1,7 @@
+package com.fastcampus.finalproject.config.security.jwt.utils;
+
+public enum TokenValidityCode {
+    VALID,
+    EXPIRED,
+    INVALID
+}

--- a/src/main/java/com/fastcampus/finalproject/controller/UserController.java
+++ b/src/main/java/com/fastcampus/finalproject/controller/UserController.java
@@ -1,30 +1,18 @@
 package com.fastcampus.finalproject.controller;
 
 import com.fastcampus.finalproject.config.security.AuthUtil;
-import com.fastcampus.finalproject.config.security.jwt.utils.AccessTokenUtility;
-import com.fastcampus.finalproject.config.security.jwt.utils.RefreshTokenUtility;
 import com.fastcampus.finalproject.dto.ResponseWrapper;
 import com.fastcampus.finalproject.dto.request.NewPasswordDto;
 import com.fastcampus.finalproject.dto.request.SignUpInfoDto;
 import com.fastcampus.finalproject.dto.request.auth.IdDto;
+import com.fastcampus.finalproject.dto.request.auth.TokenPairDto;
 import com.fastcampus.finalproject.dto.response.IdAvailabilityDto;
 import com.fastcampus.finalproject.dto.response.JwtDto;
 import com.fastcampus.finalproject.dto.response.SignUpResultDto;
 import com.fastcampus.finalproject.entity.UserBasic;
-import com.fastcampus.finalproject.entity.UserRefreshToken;
 import com.fastcampus.finalproject.enums.LoginType;
-import com.fastcampus.finalproject.repository.NativeLoginUserRepository;
-import com.fastcampus.finalproject.repository.RefreshTokenRepository;
 import com.fastcampus.finalproject.repository.UserRepository;
 import com.fastcampus.finalproject.service.UserService;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SecurityException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,20 +24,12 @@ import java.util.Optional;
 @RestController
 public class UserController {
 
-    private final AccessTokenUtility accessTokenUtility;
-    private final RefreshTokenUtility refreshTokenUtility;
     private final UserService userService;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
-    private final NativeLoginUserRepository nativeLoginUserRepository;
 
-    public UserController(AccessTokenUtility accessTokenUtility, RefreshTokenUtility refreshTokenUtility, UserService userService, RefreshTokenRepository refreshTokenRepository, UserRepository userRepository, NativeLoginUserRepository nativeLoginUserRepository) {
-        this.accessTokenUtility = accessTokenUtility;
-        this.refreshTokenUtility = refreshTokenUtility;
+    public UserController(UserService userService, UserRepository userRepository) {
         this.userService = userService;
-        this.refreshTokenRepository = refreshTokenRepository;
         this.userRepository = userRepository;
-        this.nativeLoginUserRepository = nativeLoginUserRepository;
     }
 
     @PostMapping("/sign-up")
@@ -76,18 +56,9 @@ public class UserController {
     }
 
     @PostMapping("/token/refresh")
-    public ResponseWrapper<JwtDto> issueNewTokenPair(@RequestBody String refreshToken) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SecurityException, IllegalArgumentException {
-        refreshTokenUtility.validateToken(refreshToken); // throws exceptions, exceptions will be handled in controller advice
-
-        Long userUid = refreshTokenUtility.extractSubValueFromPayload(refreshToken);
-        Authentication newAuthToken = new UsernamePasswordAuthenticationToken(userUid, new SimpleGrantedAuthority("ROLE_USER"));
-
-        String newAccessToken = accessTokenUtility.createJsonWebToken(newAuthToken);
-        String newRefreshToken = refreshTokenUtility.createRefreshJsonWebToken(newAuthToken);
-
-        refreshTokenRepository.save(new UserRefreshToken(userUid, newRefreshToken));
-
-        return new ResponseWrapper<>(new JwtDto(newAccessToken, newRefreshToken));
+    public ResponseWrapper<JwtDto> issueNewTokenPair(@RequestBody TokenPairDto tokenPairDto) {
+        JwtDto newTokenPair = userService.issueNewTokenPairs(tokenPairDto);
+        return new ResponseWrapper<>(newTokenPair).ok();
     }
 
     @GetMapping("/test/authorization")

--- a/src/main/java/com/fastcampus/finalproject/controller/advice/UserControllerAdvice.java
+++ b/src/main/java/com/fastcampus/finalproject/controller/advice/UserControllerAdvice.java
@@ -1,0 +1,31 @@
+package com.fastcampus.finalproject.controller.advice;
+
+import com.fastcampus.finalproject.controller.UserController;
+import com.fastcampus.finalproject.dto.ErrorResponseWrapper;
+import com.fastcampus.finalproject.exception.token.AccessTokenStillValidException;
+import com.fastcampus.finalproject.exception.token.AccessTokenInvalidException;
+import com.fastcampus.finalproject.exception.token.RefreshTokenInvalidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = UserController.class)
+public class UserControllerAdvice {
+
+    @ExceptionHandler(value = AccessTokenStillValidException.class)
+    public ErrorResponseWrapper handleAccessTokenStillValidException(AccessTokenStillValidException ex) {
+        ErrorResponseWrapper errorResponse = new ErrorResponseWrapper("ACCESS_TOKEN_STILL_VALID", ex.getMessage());
+        return errorResponse.badRequest();
+    }
+
+    @ExceptionHandler(value = AccessTokenInvalidException.class)
+    public ErrorResponseWrapper handleAccessTokenInvalidException(AccessTokenInvalidException ex) {
+        ErrorResponseWrapper errorResponse = new ErrorResponseWrapper("ACCESS_TOKEN_INVALID", ex.getMessage());
+        return errorResponse.badRequest();
+    }
+
+    @ExceptionHandler(value = RefreshTokenInvalidException.class)
+    public ErrorResponseWrapper handleRefreshTokenInvalidException(RefreshTokenInvalidException ex) {
+        ErrorResponseWrapper errorResponse = new ErrorResponseWrapper("REFRESH_TOKEN_INVALID", ex.getMessage());
+        return errorResponse.badRequest();
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/dto/request/auth/TokenPairDto.java
+++ b/src/main/java/com/fastcampus/finalproject/dto/request/auth/TokenPairDto.java
@@ -1,0 +1,16 @@
+package com.fastcampus.finalproject.dto.request.auth;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class TokenPairDto {
+    private String accessToken;
+    private String refreshToken;
+
+    public TokenPairDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/exception/token/AccessTokenInvalidException.java
+++ b/src/main/java/com/fastcampus/finalproject/exception/token/AccessTokenInvalidException.java
@@ -1,0 +1,7 @@
+package com.fastcampus.finalproject.exception.token;
+
+public class AccessTokenInvalidException extends RuntimeException{
+    public AccessTokenInvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/exception/token/AccessTokenStillValidException.java
+++ b/src/main/java/com/fastcampus/finalproject/exception/token/AccessTokenStillValidException.java
@@ -1,0 +1,7 @@
+package com.fastcampus.finalproject.exception.token;
+
+public class AccessTokenStillValidException extends RuntimeException{
+    public AccessTokenStillValidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/exception/token/RefreshTokenInvalidException.java
+++ b/src/main/java/com/fastcampus/finalproject/exception/token/RefreshTokenInvalidException.java
@@ -1,0 +1,7 @@
+package com.fastcampus.finalproject.exception.token;
+
+public class RefreshTokenInvalidException extends RuntimeException {
+    public RefreshTokenInvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/service/UserService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/UserService.java
@@ -1,15 +1,27 @@
 package com.fastcampus.finalproject.service;
 
+import com.fastcampus.finalproject.config.security.jwt.utils.AccessTokenUtility;
+import com.fastcampus.finalproject.config.security.jwt.utils.RefreshTokenUtility;
+import com.fastcampus.finalproject.config.security.jwt.utils.TokenValidityCode;
 import com.fastcampus.finalproject.dto.request.NewPasswordDto;
 import com.fastcampus.finalproject.dto.request.SignUpInfoDto;
+import com.fastcampus.finalproject.dto.request.auth.TokenPairDto;
+import com.fastcampus.finalproject.dto.response.JwtDto;
 import com.fastcampus.finalproject.dto.response.SignUpResultDto;
 import com.fastcampus.finalproject.entity.NativeLoginUser;
 import com.fastcampus.finalproject.entity.UserBasic;
+import com.fastcampus.finalproject.entity.UserRefreshToken;
 import com.fastcampus.finalproject.enums.LoginType;
+import com.fastcampus.finalproject.exception.token.AccessTokenInvalidException;
+import com.fastcampus.finalproject.exception.token.AccessTokenStillValidException;
 import com.fastcampus.finalproject.exception.DuplicateIdException;
+import com.fastcampus.finalproject.exception.token.RefreshTokenInvalidException;
 import com.fastcampus.finalproject.repository.NativeLoginUserRepository;
+import com.fastcampus.finalproject.repository.RefreshTokenRepository;
 import com.fastcampus.finalproject.repository.UserRepository;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -22,11 +34,18 @@ public class UserService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final UserRepository userRepository;
     private final NativeLoginUserRepository nativeLoginUserRepository;
+    private final AccessTokenUtility accessTokenUtility;
+    private final RefreshTokenUtility refreshTokenUtility;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public UserService(BCryptPasswordEncoder bCryptPasswordEncoder, UserRepository userRepository, NativeLoginUserRepository nativeLoginUserRepository) {
+
+    public UserService(BCryptPasswordEncoder bCryptPasswordEncoder, UserRepository userRepository, NativeLoginUserRepository nativeLoginUserRepository, AccessTokenUtility accessTokenUtility, RefreshTokenUtility refreshTokenUtility, RefreshTokenRepository refreshTokenRepository) {
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.userRepository = userRepository;
         this.nativeLoginUserRepository = nativeLoginUserRepository;
+        this.accessTokenUtility = accessTokenUtility;
+        this.refreshTokenUtility = refreshTokenUtility;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     public SignUpResultDto signUp(SignUpInfoDto signUpInfoDto) {
@@ -59,6 +78,34 @@ public class UserService {
         nativeLoginUserRepository.save(nativeLoginUser);
 
         return true;
+    }
+
+    public JwtDto issueNewTokenPairs(TokenPairDto tokenPairDto) {
+        String accessToken = tokenPairDto.getAccessToken();
+        String refreshToken = tokenPairDto.getRefreshToken();
+
+        switch (accessTokenUtility.evaluateTokenValidity(accessToken)) {
+            case VALID:
+                throw new AccessTokenStillValidException("액세스 토큰이 아직 유효합니다.");
+            case INVALID:
+                throw new AccessTokenInvalidException("유효하지 않은 액세스 토큰입니다");
+            default: // It falls through this switch statement when the access token is expired but valid.
+                break;
+        }
+
+        if (refreshTokenUtility.evaluateTokenValidity(refreshToken) != TokenValidityCode.VALID) {
+            throw new RefreshTokenInvalidException("유효하지 않은 리프레시 토큰입니다");
+        }
+
+        Long userUid = refreshTokenUtility.extractSubValueFromPayload(refreshToken);
+        Authentication newAuthToken = new UsernamePasswordAuthenticationToken(userUid, new SimpleGrantedAuthority("ROLE_USER"));
+
+        String newAccessToken = accessTokenUtility.createJsonWebToken(newAuthToken);
+        String newRefreshToken = refreshTokenUtility.createRefreshJsonWebToken(newAuthToken);
+
+        refreshTokenRepository.save(new UserRefreshToken(userUid, newRefreshToken));
+
+        return new JwtDto(newAccessToken, newRefreshToken);
     }
 
 }


### PR DESCRIPTION
## Related Issues
+ solved #52 

<br>

## What does this PR do?
 + [x] 사용자가 기존 토큰쌍(access token, refresh token)을 가지고 `/token/refresh`로 `POST` 요청 시, 새로운 JWT 토큰쌍을 반환합니다. 
 + [x] 만약 사용자가 제공한 기존 토큰쌍에 잘못된 값이 있을 경우, 각 에러에 맞는 에러 메시지를 사용자에게 응답으로 보냅니다.
 + [x] 보안 설정에서 해당 URL(`/token/refresh`)을 인증 정보 없이 접근 가능한 URL로 추가하였습니다.

<br>