### PR TITLE
배포 서버에서도 한국 시간 기준으로 timestamp가 반환되도록 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
+++ b/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
@@ -5,15 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import javax.annotation.PostConstruct;
+import java.time.ZoneId;
 import java.util.TimeZone;
 
 @SpringBootApplication
 public class FinalProjectApplication {
-
-	@PostConstruct
-	void started() {
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(FinalProjectApplication.class, args);

--- a/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
+++ b/src/main/java/com/fastcampus/finalproject/FinalProjectApplication.java
@@ -2,11 +2,6 @@ package com.fastcampus.finalproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-import javax.annotation.PostConstruct;
-import java.time.ZoneId;
-import java.util.TimeZone;
 
 @SpringBootApplication
 public class FinalProjectApplication {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,9 @@ spring:
     host: localHost
     port: 6379
 
+  jackson:
+    time-zone: Asia/Seoul
+
 logging:
   level:
     org.hibernate.SQL: debug # dml 쿼리에 대해 debug 이상의 로그 출력


### PR DESCRIPTION
## Related Issues
+ solved #34 
+ 스프링 부트는 jackson 라이브러리로 spring mvc의 요청 및 응답을 처리한다. 기본적으로 제공하는 404 Not Found나 500 Internal Server Error 같은 경우, 응답으로 `timestamp` `status` `error` `path`를 반환하게 된다. appication.yml에서 jackson에 대한 time-zone을 설정하면 timestamp가 설정값에 따라 변한다.

<br>

## What does this PR do?
 + [x] application.yml에 jackson 관련 코드 추가
 + [x] FinalProjectApplication에서 이전에 작성했던 코드 삭제

<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
