### PR TITLE
Redis entity인 UserRefreshToken의 TimeToLive 오류 수정

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/entity/UserRefreshToken.java
+++ b/src/main/java/com/fastcampus/finalproject/entity/UserRefreshToken.java
@@ -3,7 +3,7 @@ package com.fastcampus.finalproject.entity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
-@RedisHash(timeToLive = 86400 * 24)
+@RedisHash(timeToLive = 86400)
 public class UserRefreshToken {
 
     private Long uid;


### PR DESCRIPTION
## Related Issues
+ solved #65 

<br>

## What does this PR do?
 + [x] UserRefreshToken의 유효시간(time to live)를 24일에서 24시간으로 수정하였습니다.

<br>