### PR TITLE
504 Gateway timeout 해결을 위한 Configuration, Bean 추가

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/config/RestTemplateConfig.java
+++ b/src/main/java/com/fastcampus/finalproject/config/RestTemplateConfig.java
@@ -1,0 +1,38 @@
+package com.fastcampus.finalproject.config;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    //Connection Pool을 사용하는 것과 같이 동작하기 위한 코드
+    @Bean
+    protected HttpClient httpClient() {
+        return HttpClientBuilder.create()
+                .setMaxConnTotal(50) // 최대로 연결을 유지할 커넥션 수
+                .setMaxConnPerRoute(20) // IP, Port 한 쌍에 대해 수행할 커넥션 수
+                .build();
+    }
+
+    @Bean
+    protected HttpComponentsClientHttpRequestFactory httpComponentsClientHttpRequestFactory(HttpClient httpClient) {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(1000 * 5);
+        factory.setReadTimeout(1000 * 60 * 5);
+        factory.setHttpClient(httpClient);
+        return factory;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate(httpComponentsClientHttpRequestFactory(httpClient()));
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/service/FlaskCommunicationService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/FlaskCommunicationService.java
@@ -1,5 +1,6 @@
 package com.fastcampus.finalproject.service;
 
+import com.fastcampus.finalproject.config.RestTemplateConfig;
 import com.fastcampus.finalproject.config.YmlFlaskConfig;
 import com.fastcampus.finalproject.enums.FileType;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,6 +25,7 @@ public class FlaskCommunicationService {
 
     private final ObjectMapper objectMapper;
     private final YmlFlaskConfig flaskConfig;
+    private final RestTemplateConfig restTemplateConfig;
 
     public AudioResponse getAudioResult(AudioRequest request) {
         try {
@@ -67,8 +69,7 @@ public class FlaskCommunicationService {
 
     private ResponseEntity<String> getResponseEntity(HttpEntity<String> entity, String requestApi) {
         //RestTemplate의 exchange 메서드로 URL에 httpEntity와 함께 요청하기
-        RestTemplate restTemplate = new RestTemplate();
-        return restTemplate.exchange(
+        return restTemplateConfig.restTemplate().exchange(
                 requestApi,
                 HttpMethod.POST,
                 entity,


### PR DESCRIPTION
## Related Issues
+ solved #79 

<br>

## What does this PR do?
 - [x] RestTemplate을 커스텀하기 위한 RestTemplateConfiguration 추가
 - [x] Connection Pool 처럼 사용하기 위함으로 HttpClient을 반환하는 Bean 객체 추가
 - [x] HttpClient 적용 및 timeout을 설정하기 위함으로 HttpComponentsClientHttpRequestFactory을 반환하는 Bean 객체 추가
 - [x] 위의 설정을 포함한 RestTemplate을 반환하는 Bean 객체 추가
 - [x] FlaskCommunication에서 RestTemplateConfiguration을 DI하고 Bean으로 등록된 RestTemplate 사용 
