### PR TITLE
fix: 텍스트 페이지에서 조회가 아닌 텍스트 페이지에서 음성 파일을 생성하기 전에 검증

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
@@ -128,6 +128,7 @@ public class ProjectService {
     public TotalAudioSyntheticResponse addAudioInfo(Long projectId, TotalAudioSyntheticRequest request) {
         Project findProject = projectRepository.findWithUserById(projectId).orElseThrow(NoSuchElementException::new);
         validateAccessOnCurrentUser(findProject.getUser());
+        validateSameTextsAndSplitTextList(request);
 
         request.changeAudioInfo(findProject.getAudio());
 
@@ -140,6 +141,16 @@ public class ProjectService {
             return new TotalAudioSyntheticResponse("Success", savedFileBucketUrl);
         } else {
             return new TotalAudioSyntheticResponse("Failed", null);
+        }
+    }
+
+    private void validateSameTextsAndSplitTextList(TotalAudioSyntheticRequest request) {
+        List<String> textList = Stream.of(request.getTexts().split("\\."))
+                .map(String::trim)
+                .collect(Collectors.toList());
+
+        if(textList.size() != request.getSplitTextList().size()) {
+            throw new NotSameSizeTwoListsException();
         }
     }
 
@@ -337,10 +348,6 @@ public class ProjectService {
         List<Integer> sentenceSpacingList = Stream.of(findProject.getAudio().getSentenceSpacingList().split("\\|"))
                 .map(Integer::parseInt)
                 .collect(Collectors.toList());
-
-        if(textList.size() != sentenceSpacingList.size()) {
-            throw new NotSameSizeTwoListsException();
-        }
 
         List<TextDto> splitTextList = new ArrayList<>();
         for (int i = 0; i < textList.size(); i++) {


### PR DESCRIPTION
## Related Issues
+ solved #90 

<br>

## What does this PR do?
 + [x] 텍스트 페이지에서 음성 파일을 생성하기 전에 texts와 splitTextList의 유효성을 검증하도록 코드 반영함

<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
