### PR TITLE
중복 로그인 방지 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/finalproject/config/SecurityConfig.java
@@ -10,7 +10,8 @@ import com.fastcampus.finalproject.config.security.jwt.handler.JwtAuthentication
 import com.fastcampus.finalproject.config.security.jwt.provider.CustomAuthenticationProvider;
 import com.fastcampus.finalproject.config.security.jwt.utils.AccessTokenUtility;
 import com.fastcampus.finalproject.config.security.jwt.utils.RefreshTokenUtility;
-import com.fastcampus.finalproject.repository.RefreshTokenRepository;
+import com.fastcampus.finalproject.repository.RedisAccessTokenRepository;
+import com.fastcampus.finalproject.repository.RedisRefreshTokenRepository;
 import com.fastcampus.finalproject.repository.SocialLoginUserRepository;
 import com.fastcampus.finalproject.repository.UserRepository;
 import com.fastcampus.finalproject.service.auth.CustomOAuth2UserService;
@@ -53,7 +54,8 @@ public class SecurityConfig {
 
     private final AccessTokenUtility accessTokenUtility;
     private final RefreshTokenUtility refreshTokenUtility;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RedisAccessTokenRepository redisAccessTokenRepository;
+    private final RedisRefreshTokenRepository redisRefreshTokenRepository;
     private final UserRepository userRepository;
     private final SocialLoginUserRepository socialLoginUserRepository;
     private final CustomUserDetailsService userDetailsService;
@@ -61,10 +63,14 @@ public class SecurityConfig {
     private static String CLIENT_PROPERTY_KEY = "spring.security.oauth2.client.registration.";
 
 
-    public SecurityConfig(AccessTokenUtility accessTokenUtility, RefreshTokenUtility refreshTokenUtility, RefreshTokenRepository refreshTokenRepository, CustomUserDetailsService customUserDetailsService, UserRepository userRepository, SocialLoginUserRepository socialLoginUserRepository, Environment env) {
+    public SecurityConfig(AccessTokenUtility accessTokenUtility, RefreshTokenUtility refreshTokenUtility,
+                          RedisAccessTokenRepository redisAccessTokenRepository, RedisRefreshTokenRepository redisRefreshTokenRepository,
+                          CustomUserDetailsService customUserDetailsService,
+                          UserRepository userRepository, SocialLoginUserRepository socialLoginUserRepository, Environment env) {
         this.accessTokenUtility = accessTokenUtility;
         this.refreshTokenUtility = refreshTokenUtility;
-        this.refreshTokenRepository = refreshTokenRepository;
+        this.redisAccessTokenRepository = redisAccessTokenRepository;
+        this.redisRefreshTokenRepository = redisRefreshTokenRepository;
         this.userDetailsService = customUserDetailsService;
         this.userRepository = userRepository;
         this.socialLoginUserRepository = socialLoginUserRepository;
@@ -121,7 +127,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(accessTokenUtility);
+        return new JwtAuthorizationFilter(this.accessTokenUtility, this.redisAccessTokenRepository);
     }
 
 
@@ -141,7 +147,7 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationSuccessHandler authenticationSuccessHandler() {
-        return new JwtAuthenticationSuccessHandler(accessTokenUtility, refreshTokenUtility, refreshTokenRepository);
+        return new JwtAuthenticationSuccessHandler(this.accessTokenUtility, this.refreshTokenUtility, this.redisAccessTokenRepository, this.redisRefreshTokenRepository);
     }
 
     @Bean

--- a/src/main/java/com/fastcampus/finalproject/config/security/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/fastcampus/finalproject/config/security/jwt/filter/JwtAuthorizationFilter.java
@@ -1,6 +1,13 @@
 package com.fastcampus.finalproject.config.security.jwt.filter;
 
 import com.fastcampus.finalproject.config.security.jwt.utils.AccessTokenUtility;
+import com.fastcampus.finalproject.config.security.jwt.utils.TokenValidityCode;
+import com.fastcampus.finalproject.entity.UserAccessToken;
+import com.fastcampus.finalproject.exception.token.AccessTokenInvalidException;
+import com.fastcampus.finalproject.repository.RedisAccessTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SecurityException;
+import org.apache.catalina.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
@@ -13,26 +20,35 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
 
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthorizationFilter.class);
     public static final String AUTHORIZATION_HEADER = "Authorization";
     private final AccessTokenUtility accessTokenUtility;
+    private final RedisAccessTokenRepository redisAccessTokenRepository;
 
-    public JwtAuthorizationFilter(AccessTokenUtility accessTokenUtility) {
+    public JwtAuthorizationFilter(AccessTokenUtility accessTokenUtility, RedisAccessTokenRepository redisAccessTokenRepository) {
         this.accessTokenUtility = accessTokenUtility;
+        this.redisAccessTokenRepository = redisAccessTokenRepository;
     }
 
     @Override
-    public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+    public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException, SecurityException {
         String jwt = resolveTokenFromHttpHeader(servletRequest);
         String requestURI = servletRequest.getRequestURI();
 
         if (StringUtils.hasText(jwt) && accessTokenUtility.validateToken(jwt)) {
-
             Authentication authentication = accessTokenUtility.getAuthenticationTokenFromJwt(jwt);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            Optional<UserAccessToken> tokenOptional = redisAccessTokenRepository.findById((Long) authentication.getPrincipal());
+
+            if (tokenOptional.isPresent() && tokenOptional.get().getAccessToken().equals(jwt)) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                throw new SecurityException("message");
+            }
 
             logger.debug("Authentication info stored in the security context. Principal: '{}', URI: {}", authentication.getName(), requestURI);
         } else {

--- a/src/main/java/com/fastcampus/finalproject/entity/UserAccessToken.java
+++ b/src/main/java/com/fastcampus/finalproject/entity/UserAccessToken.java
@@ -1,0 +1,24 @@
+package com.fastcampus.finalproject.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(timeToLive = 3600)
+public class UserAccessToken {
+    private Long uid;
+    private String accessToken;
+
+    public UserAccessToken(Long uid, String accessToken) {
+        this.uid = uid;
+        this.accessToken = accessToken;
+    }
+
+    @Id
+    public Long getUid() {
+        return this.uid;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+}

--- a/src/main/java/com/fastcampus/finalproject/repository/RedisAccessTokenRepository.java
+++ b/src/main/java/com/fastcampus/finalproject/repository/RedisAccessTokenRepository.java
@@ -1,0 +1,8 @@
+package com.fastcampus.finalproject.repository;
+
+import com.fastcampus.finalproject.entity.UserAccessToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisAccessTokenRepository extends CrudRepository<UserAccessToken, Long> {
+
+}

--- a/src/main/java/com/fastcampus/finalproject/repository/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/fastcampus/finalproject/repository/RedisRefreshTokenRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RefreshTokenRepository extends CrudRepository<UserRefreshToken, Long> {
+public interface RedisRefreshTokenRepository extends CrudRepository<UserRefreshToken, Long> {
 
 }


### PR DESCRIPTION
## Related Issues
+ solved #53 

<br>

## What does this PR do?
 + [x] 중복 로그인 방지 기능을 구현하기 위해서는 인증에 성공한 사용자에게 가장 마지막에 발급된 Access token을 저장해야 하며, 이를 위해 `UserAccessToken` 클래스와, Redis에 이를 저장하기 위한 `RedisAccessTokenRepository`를 구현하였습니다.
 + [x] `RefreshTokenRepository` 인터페이스의 이름이 `**Redis**RefreshTokenRepository`로 수정되었습니다.
 + [x] 중복 로그인 방지 기능을 구현함에 따라, 인증 성공 처리 로직(`JwtAuthenticationSuccessHandler`)과 인가 처리 로직(`JwtAuthorizationFilter`)의 처리 로직이 변경되었습니다. (자세한 내용은 해당 커밋을 참고)
 + [x] 상기 변동 사항에 따라 `SecurityConfig`에서 관련 Bean 클래스의 의존성 주입 관련 코드가 수정되었습니다.

<br>