### PR TITLE
영상 생성을 요청하는 비즈니스 로직과 가장 오래된 영상을 삭제하는 비즈니스 로직 분리

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/controller/ProjectController.java
+++ b/src/main/java/com/fastcampus/finalproject/controller/ProjectController.java
@@ -86,7 +86,9 @@ public class ProjectController {
      * */
     @PostMapping("/projects/{projectId}/avatar")
     public ResponseWrapper<CompleteAvatarPageResponse> addAvatarInfo(@PathVariable Long projectId, @RequestBody AvatarPageRequest request) {
-        return new ResponseWrapper<>(projectService.addAvatarInfo(projectId, request))
+        CompleteAvatarPageResponse response = projectService.addAvatarInfo(projectId, request);
+        projectService.deleteOldestVideo(AuthUtil.getCurrentUserUid());
+        return new ResponseWrapper<>(response)
                 .ok();
     }
 


### PR DESCRIPTION
## Related Issues
+ none

<br>

## What does this PR do?
 + [x] save()와 delete() 메서드가 하나의 Transactional에서 실행됨에 따라 이후의 버그를 차단하기 위해 철저히 분리시킴
 + [x] Controller단에서 두 비즈니스 메서드(1. 영상 생성 요청, 2. 가장 오래된 비디오 삭제)를 차례대로 호출
