### PR TITLE
feat: 한 문장에 대한 오디오 파일을 생성할 때 로컬 파일에서 삭제시키는 기능 추가

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
+++ b/src/main/java/com/fastcampus/finalproject/aws/S3Uploader.java
@@ -31,10 +31,9 @@ public class S3Uploader {
     public void removeFile(String parentPath, FileType fileType, String fileName, String fileExtension) {
         amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, parentPath + "/" + fileType.getValue() + "/" + fileName + fileExtension));
 
+        if(fileName == null) return;
         File file = new File(flaskConfig.getFilePath() + "/" + fileName + fileExtension);
-        if(file.exists()) {
-            removeLocalFile(file);
-        }
+        removeLocalFile(file);
     }
 
     /*

--- a/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
+++ b/src/main/java/com/fastcampus/finalproject/service/ProjectService.java
@@ -205,8 +205,10 @@ public class ProjectService {
         );
 
         String audioFilePath = flaskConfig.createAudioFilePath(audioResponse.getId());
-        byte[] audioBinaryFile = getAudioFileBinary(audioFilePath);
+        File file = new File(audioFilePath);
+        byte[] audioBinaryFile = getAudioFileBinary(file);
         String audioBase64toString = Base64.getEncoder().encodeToString(audioBinaryFile);
+        s3Uploader.removeLocalFile(file);
 
         if (audioResponse.getStatus().equals("Success")) {
             return new SentenceInputResponse(audioResponse.getStatus(), audioBase64toString);
@@ -215,8 +217,7 @@ public class ProjectService {
         }
     }
 
-    private static byte[] getAudioFileBinary(String filepath) {
-        File file = new File(filepath);
+    private static byte[] getAudioFileBinary(File file) {
         byte[] data = new byte[(int) file.length()];
         try (FileInputStream stream = new FileInputStream(file)) {
             stream.read(data, 0, data.length);
@@ -414,7 +415,7 @@ public class ProjectService {
     @Transactional(readOnly = true)
     public AvatarPreviewResponse getAvatarPreview(AvatarPageRequest request) {
         String filepath = flaskConfig.createImageFilePath(request.getAvatarType(), request.getBgName());
-        byte[] fileBinary = getAudioFileBinary(filepath);
+        byte[] fileBinary = getAudioFileBinary(new File(filepath));
         String base64String = Base64.getEncoder().encodeToString(fileBinary);
 
         return new AvatarPreviewResponse(base64String);


### PR DESCRIPTION
## Related Issues
+ none

<br>

## What does this PR do?
 + [x] 한 문장에 대해서 오디오 파일이 생성되면 로컬에 있는 파일을 삭제시키지 않아 파일이 계속 쌓이고 있었음. 이에 대해 s3Uploader의 removeLocalFile() 메서드로 처리함.
