### PR TITLE
feat: 프로젝트 texts 값이 미정일 경우 texts는 Blank, splitTextList는 EmptyList로 응답

### DIFF
--- a/src/main/java/com/fastcampus/finalproject/dto/TextPageDto.java
+++ b/src/main/java/com/fastcampus/finalproject/dto/TextPageDto.java
@@ -3,13 +3,18 @@ package com.fastcampus.finalproject.dto;
 import com.fastcampus.finalproject.entity.Audio;
 import com.fastcampus.finalproject.entity.Project;
 import com.fastcampus.finalproject.entity.dummy.DummyVoice;
+import com.fastcampus.finalproject.enums.ProjectDefaultType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.fastcampus.finalproject.enums.ProjectDefaultType.EMPTY;
 
 public class TextPageDto {
 
@@ -155,16 +160,28 @@ public class TextPageDto {
 
         public GetTextPageResponse(Project project, List<TextDto> splitTextList, TextPageDummyDto dummyData) {
             Audio audio = project.getAudio();
-            this.texts = audio.getTexts();
+            this.texts = getBlankIfInitProject(audio.getTexts());
             this.language = audio.getLanguage();
             this.sex = audio.getSex();
             this.characterName = audio.getCharacterVoice();
             this.speed = audio.getSpeed();
             this.pitch = audio.getPitch();
             this.sentenceSpacing = audio.getSentenceSpacing();
-            this.splitTextList = splitTextList;
+            this.splitTextList = getEmptyListIfInitProject(audio.getTexts(), splitTextList);
             this.totalAudioUrl = project.getTotalAudioUrl();
             this.dummyData = dummyData;
+        }
+
+        private String getBlankIfInitProject(String texts) {
+            return isEmptyTexts(texts) ? "" : texts;
+        }
+
+        private List<TextDto> getEmptyListIfInitProject(String texts, List<TextDto> splitTextList) {
+            return isEmptyTexts(texts) ? Collections.emptyList() : splitTextList;
+        }
+
+        private boolean isEmptyTexts(String texts) {
+            return texts.equals(EMPTY.getValue());
         }
 
         @Data

--- a/src/main/java/com/fastcampus/finalproject/dto/TextPageDto.java
+++ b/src/main/java/com/fastcampus/finalproject/dto/TextPageDto.java
@@ -3,13 +3,11 @@ package com.fastcampus.finalproject.dto;
 import com.fastcampus.finalproject.entity.Audio;
 import com.fastcampus.finalproject.entity.Project;
 import com.fastcampus.finalproject.entity.dummy.DummyVoice;
-import com.fastcampus.finalproject.enums.ProjectDefaultType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## Related Issues
+ none

<br>

## What does this PR do?
 + [x] 신규 프로젝트 생성 -> 텍스트 페이지로 이동 하게 됐을 경우, 초기 default 값이 미정이어서 texts와 splitTextList에 그대로 노출되는 경우가 발생하여 이에 대해 대처함

<br>

## Solved Problem (Optional)
 + ~한 문제가 발생했는데 ~를 도입하여 해결할 수 있었음
